### PR TITLE
Refactor navigation items to wrap anchors outside NavItem components

### DIFF
--- a/src/app/blog/BlogNav.tsx
+++ b/src/app/blog/BlogNav.tsx
@@ -24,18 +24,18 @@ export function BlogNav() {
       }
       rightSlot={
         <div className="flex items-center justify-end gap-2 mobile:flex-row mobile:flex-nowrap mobile:items-center mobile:justify-end mobile:gap-2 mobile:px-2 mobile:py-2">
-          <TopbarWithRightNav.NavItem>
-            <a href="/">About</a>
-          </TopbarWithRightNav.NavItem>
-          <TopbarWithRightNav.NavItem selected={true}>
-            <a href="/blog">Blog</a>
-          </TopbarWithRightNav.NavItem>
-          <TopbarWithRightNav.NavItem>
-            <a href="/community">Community</a>
-          </TopbarWithRightNav.NavItem>
-          <TopbarWithRightNav.NavItem>
-            <a href="https://cartography-cncf.github.io/cartography/">Docs</a>
-          </TopbarWithRightNav.NavItem>
+          <a href="/">
+            <TopbarWithRightNav.NavItem>About</TopbarWithRightNav.NavItem>
+          </a>
+          <a href="/blog">
+            <TopbarWithRightNav.NavItem selected={true}>Blog</TopbarWithRightNav.NavItem>
+          </a>
+          <a href="/community">
+            <TopbarWithRightNav.NavItem>Community</TopbarWithRightNav.NavItem>
+          </a>
+          <a href="https://cartography-cncf.github.io/cartography/">
+            <TopbarWithRightNav.NavItem>Docs</TopbarWithRightNav.NavItem>
+          </a>
         </div>
       }
     />

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -44,18 +44,18 @@ function Community() {
         }
         rightSlot={
           <div className="flex items-center justify-end gap-2 mobile:px-2 mobile:py-2">
-            <TopbarWithRightNav.NavItem>
-              <a href="/">About</a>
-            </TopbarWithRightNav.NavItem>
-            <TopbarWithRightNav.NavItem>
-                <a href="/blog">Blog</a>
-            </TopbarWithRightNav.NavItem>
-            <TopbarWithRightNav.NavItem selected={true}>
-                <a href="/community">Community</a>
-            </TopbarWithRightNav.NavItem>
-            <TopbarWithRightNav.NavItem>
-                <a href="https://cartography-cncf.github.io/cartography/">Docs</a>
-            </TopbarWithRightNav.NavItem>
+            <a href="/">
+              <TopbarWithRightNav.NavItem>About</TopbarWithRightNav.NavItem>
+            </a>
+            <a href="/blog">
+              <TopbarWithRightNav.NavItem>Blog</TopbarWithRightNav.NavItem>
+            </a>
+            <a href="/community">
+              <TopbarWithRightNav.NavItem selected={true}>Community</TopbarWithRightNav.NavItem>
+            </a>
+            <a href="https://cartography-cncf.github.io/cartography/">
+              <TopbarWithRightNav.NavItem>Docs</TopbarWithRightNav.NavItem>
+            </a>
           </div>
         }
       />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,18 +34,18 @@ function About() {
         }
         rightSlot={
           <div className="flex items-center justify-end gap-2 mobile:flex-row mobile:flex-nowrap mobile:items-center mobile:justify-end mobile:gap-2 mobile:px-2 mobile:py-2">
-            <TopbarWithRightNav.NavItem selected={true}>
-              <a href="/">About</a>
-            </TopbarWithRightNav.NavItem>
-            <TopbarWithRightNav.NavItem>
-                <a href="/blog">Blog</a>
-            </TopbarWithRightNav.NavItem>
-            <TopbarWithRightNav.NavItem>
-                <a href="/community">Community</a>
-            </TopbarWithRightNav.NavItem>
-            <TopbarWithRightNav.NavItem>
-                <a href="https://cartography-cncf.github.io/cartography/">Docs</a>
-            </TopbarWithRightNav.NavItem>
+            <a href="/">
+              <TopbarWithRightNav.NavItem selected={true}>About</TopbarWithRightNav.NavItem>
+            </a>
+            <a href="/blog">
+              <TopbarWithRightNav.NavItem>Blog</TopbarWithRightNav.NavItem>
+            </a>
+            <a href="/community">
+              <TopbarWithRightNav.NavItem>Community</TopbarWithRightNav.NavItem>
+            </a>
+            <a href="https://cartography-cncf.github.io/cartography/">
+              <TopbarWithRightNav.NavItem>Docs</TopbarWithRightNav.NavItem>
+            </a>
           </div>
         }
       />
@@ -307,20 +307,20 @@ function About() {
         centerSlot={
           <>
             <div className="flex items-start gap-4">
-              <TopbarWithRightNav.NavItem selected={true}>
-                <a href="/">About</a>
-              </TopbarWithRightNav.NavItem>
+              <a href="/">
+                <TopbarWithRightNav.NavItem selected={true}>About</TopbarWithRightNav.NavItem>
+              </a>
             </div>
             <div className="flex items-center justify-end gap-2">
-              <TopbarWithRightNav.NavItem>
-                <a href="/blog">Blog</a>
-              </TopbarWithRightNav.NavItem>
-              <TopbarWithRightNav.NavItem>
-                <a href="/community">Community</a>
-              </TopbarWithRightNav.NavItem>
-              <TopbarWithRightNav.NavItem>
-                <a href="https://cartography-cncf.github.io/cartography/">Docs</a>
-              </TopbarWithRightNav.NavItem>
+              <a href="/blog">
+                <TopbarWithRightNav.NavItem>Blog</TopbarWithRightNav.NavItem>
+              </a>
+              <a href="/community">
+                <TopbarWithRightNav.NavItem>Community</TopbarWithRightNav.NavItem>
+              </a>
+              <a href="https://cartography-cncf.github.io/cartography/">
+                <TopbarWithRightNav.NavItem>Docs</TopbarWithRightNav.NavItem>
+              </a>
             </div>
           </>
         }


### PR DESCRIPTION
## Summary
This PR restructures the navigation component hierarchy across multiple pages by moving anchor (`<a>`) elements outside of `TopbarWithRightNav.NavItem` components. This change improves semantic HTML structure and ensures proper link behavior.

## Key Changes
- **src/app/page.tsx**: Refactored navigation items in both the `rightSlot` and `centerSlot` sections to wrap `NavItem` components with anchor tags
- **src/app/blog/BlogNav.tsx**: Updated the blog navigation to follow the same pattern with anchors wrapping `NavItem` components
- **src/app/community/page.tsx**: Applied consistent navigation structure changes to the community page

## Implementation Details
- Changed from: `<NavItem><a href="...">Label</a></NavItem>`
- Changed to: `<a href="..."><NavItem>Label</NavItem></a>`
- Navigation labels are now passed as direct children to `NavItem` instead of being wrapped in anchor tags
- The `selected` prop is preserved on the appropriate navigation items
- All four navigation links (About, Blog, Community, Docs) are updated consistently across all affected files

https://claude.ai/code/session_01NVhcH32JhUxBRBLHAq9hsJ