### PR TITLE
Fix canonical URL causing LinkedIn to show homepage OG metadata

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -34,6 +34,9 @@ export async function generateMetadata({
     title,
     description,
     authors: post.author ? [{ name: post.author }] : undefined,
+    alternates: {
+      canonical: `/blog/${params.slug}`,
+    },
     openGraph: {
       title: post.title,
       description,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,9 +5,6 @@ export const metadata: Metadata = {
   title: "Cartography - Open Source Infrastructure Mapping Tool",
   description: "Cartography is an open source tool that maps your infrastructure, helping you visualize relationships between services, resources, and infrastructure components.",
   metadataBase: new URL('https://cartography.dev'),
-  alternates: {
-    canonical: '/',
-  },
   icons: {
     icon: [
       {


### PR DESCRIPTION
The root layout set canonical: '/' which applied to all pages, telling crawlers (including LinkedIn) that every page's canonical version is the homepage. LinkedIn followed this and scraped homepage metadata instead of the blog post's OG tags.

- Remove global canonical from root layout
- Add per-post canonical URLs in blog post generateMetadata

https://claude.ai/code/session_01RBPhgVYVQhTEKLqeiyDUJF