### PR TITLE
Add three external blog/talk references by Jeremy Chapeau

### DIFF
--- a/content/blog/graph-driven-audits-keycloak-keyconf-2025.md
+++ b/content/blog/graph-driven-audits-keycloak-keyconf-2025.md
@@ -1,0 +1,11 @@
+---
+title: "Graph-Driven Audits for Keycloak: A Deep Dive with Cartography (KeyConf 2025)"
+date: "2025-08-28"
+summary: "Conference talk at KeyConf 2025 in Amsterdam on using Cartography for graph-driven audits of Keycloak."
+author: "Jeremy Chapeau"
+authorUrl: "https://www.linkedin.com/in/jchapeau/"
+---
+
+*Talk presented at KeyConf 2025, Amsterdam, Netherlands.*
+
+[Watch on YouTube →](https://youtu.be/fGkVra628OU)

--- a/content/blog/unifying-the-graph-ontology.md
+++ b/content/blog/unifying-the-graph-ontology.md
@@ -1,0 +1,11 @@
+---
+title: "Unifying the Graph: Why We Introduced an Ontology in Cartography"
+date: "2025-06-16"
+summary: "Why Cartography introduced an ontology to unify its graph model."
+author: "Jeremy Chapeau"
+authorUrl: "https://www.linkedin.com/in/jchapeau/"
+---
+
+*This post was originally published on the author's personal blog.*
+
+[Read the full post on Medium →](https://jychp.medium.com/unifying-the-graph-why-we-introduced-an-ontology-in-cartography-33b9301de22d)

--- a/content/blog/writing-your-first-cartography-intel-module.md
+++ b/content/blog/writing-your-first-cartography-intel-module.md
@@ -1,0 +1,11 @@
+---
+title: "Writing Your First Cartography Intel Module"
+date: "2025-05-19"
+summary: "A step-by-step guide to building your first Cartography intel module."
+author: "Jeremy Chapeau"
+authorUrl: "https://www.linkedin.com/in/jchapeau/"
+---
+
+*This post was originally published on the author's personal blog.*
+
+[Read the full post on Medium →](https://jychp.medium.com/%EF%B8%8F-writing-your-first-cartography-intel-module-1b017c5425a6)


### PR DESCRIPTION
Adds three external-reference blog stubs (link-outs, no local content), following the existing convention in `content/blog/`:

- **Writing Your First Cartography Intel Module** (Medium, 2025-05-19)
- **Unifying the Graph: Why We Introduced an Ontology in Cartography** (Medium, 2025-06-16)
- **Graph-Driven Audits for Keycloak: A Deep Dive with Cartography** (KeyConf 2025 talk, 2025-08-28)

All three by Jeremy Chapeau. Each is a short stub with an italic attribution line and a single link out, matching existing posts like `mapping-moving-clouds.md` and the CNCF Security Day talk stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)